### PR TITLE
feat: Added support for AzApi v 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following requirements are needed by this module:
 
 - <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9)
 
-- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 1.15)
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 3)
 
 - <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (>= 3.116.0, < 5.0.0)
 

--- a/examples/default-azapi-v2/README.md
+++ b/examples/default-azapi-v2/README.md
@@ -1,0 +1,308 @@
+<!-- BEGIN_TF_DOCS -->
+# Example of deploying DevOps Managed Pools with Public Networking with v4.0.0 of azurerm provider
+
+This deploys the module in its simplest form with the minimum variable inputs for Azure Managed DevOps Pools. It uses public networking.
+
+```hcl
+variable "azure_devops_organization_name" {
+  type        = string
+  description = "Azure DevOps Organisation Name"
+}
+
+variable "azure_devops_personal_access_token" {
+  type        = string
+  description = "The personal access token used for authentication to Azure DevOps."
+  sensitive   = true
+}
+
+locals {
+  tags = {
+    scenario = "default"
+  }
+}
+
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 2"
+    }
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = "~> 1.1"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.5"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  azure_devops_organization_url = "https://dev.azure.com/${var.azure_devops_organization_name}"
+}
+
+provider "azuredevops" {
+  personal_access_token = var.azure_devops_personal_access_token
+  org_service_url       = local.azure_devops_organization_url
+}
+
+resource "random_string" "name" {
+  length  = 6
+  numeric = true
+  special = false
+  upper   = false
+}
+
+resource "azuredevops_project" "this" {
+  name = random_string.name.result
+}
+
+locals {
+  default_branch  = "refs/heads/main"
+  pipeline_file   = "pipeline.yml"
+  repository_name = "example-repo"
+}
+
+resource "azuredevops_git_repository" "this" {
+  project_id     = azuredevops_project.this.id
+  name           = local.repository_name
+  default_branch = local.default_branch
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_git_repository_file" "this" {
+  repository_id = azuredevops_git_repository.this.id
+  file          = local.pipeline_file
+  content = templatefile("${path.module}/${local.pipeline_file}", {
+    agent_pool_name = module.managed_devops_pool.name
+  })
+  branch              = local.default_branch
+  commit_message      = "[skip ci]"
+  overwrite_on_create = true
+}
+
+resource "azuredevops_build_definition" "this" {
+  project_id = azuredevops_project.this.id
+  name       = "Example Build Definition"
+
+  ci_trigger {
+    use_yaml = true
+  }
+
+  repository {
+    repo_type   = "TfsGit"
+    repo_id     = azuredevops_git_repository.this.id
+    branch_name = azuredevops_git_repository.this.default_branch
+    yml_path    = local.pipeline_file
+  }
+}
+
+data "azuredevops_agent_queue" "this" {
+  project_id = azuredevops_project.this.id
+  name       = module.managed_devops_pool.name
+  depends_on = [module.managed_devops_pool]
+}
+
+resource "azuredevops_pipeline_authorization" "this" {
+  project_id  = azuredevops_project.this.id
+  resource_id = data.azuredevops_agent_queue.this.id
+  type        = "queue"
+  pipeline_id = azuredevops_build_definition.this.id
+}
+
+resource "azurerm_resource_group" "this" {
+  location = local.selected_region
+  name     = "rg-${random_string.name.result}"
+}
+
+locals {
+  resource_providers_to_register = {
+    dev_center = {
+      resource_provider = "Microsoft.DevCenter"
+    }
+    devops_infrastructure = {
+      resource_provider = "Microsoft.DevOpsInfrastructure"
+    }
+  }
+}
+
+data "azurerm_client_config" "this" {}
+
+resource "azapi_resource_action" "resource_provider_registration" {
+  for_each = local.resource_providers_to_register
+
+  resource_id = "/subscriptions/${data.azurerm_client_config.this.subscription_id}"
+  type        = "Microsoft.Resources/subscriptions@2021-04-01"
+  action      = "providers/${each.value.resource_provider}/register"
+  method      = "POST"
+}
+
+resource "azurerm_dev_center" "this" {
+  location            = azurerm_resource_group.this.location
+  name                = "dc-${random_string.name.result}"
+  resource_group_name = azurerm_resource_group.this.name
+
+  depends_on = [azapi_resource_action.resource_provider_registration]
+}
+
+resource "azurerm_dev_center_project" "this" {
+  dev_center_id       = azurerm_dev_center.this.id
+  location            = azurerm_resource_group.this.location
+  name                = "dcp-${random_string.name.result}"
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+# This is the module call
+module "managed_devops_pool" {
+  source                                   = "../.."
+  resource_group_name                      = azurerm_resource_group.this.name
+  location                                 = azurerm_resource_group.this.location
+  name                                     = "mdp-${random_string.name.result}"
+  dev_center_project_resource_id           = azurerm_dev_center_project.this.id
+  version_control_system_organization_name = var.azure_devops_organization_name
+  version_control_system_project_names     = [azuredevops_project.this.name]
+  enable_telemetry                         = var.enable_telemetry
+  tags                                     = local.tags
+  depends_on                               = [azapi_resource_action.resource_provider_registration]
+}
+
+output "managed_devops_pool_id" {
+  value = module.managed_devops_pool.resource_id
+}
+
+output "managed_devops_pool_name" {
+  value = module.managed_devops_pool.name
+}
+
+# Region helpers
+module "regions" {
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+}
+
+resource "random_integer" "region_index" {
+  max = length(local.regions) - 1
+  min = 0
+}
+
+locals {
+  excluded_regions = [
+    "westeurope" # Capacity issues
+  ]
+  included_regions = [
+    "australiaeast", "brazilsouth", "canadacentral", "centralus", "westeurope", "germanywestcentral", "italynorth", "japaneast", "uksouth", "eastus", "eastus2", "southafricanorth", "southcentralus", "southeastasia", "switzerlandnorth", "swedencentral", "westus3", "centralindia", "eastasia", "northeurope", "koreacentral"
+  ]
+  regions         = [for region in module.regions.regions : region.name if !contains(local.excluded_regions, region.name) && contains(local.included_regions, region.name)]
+  selected_region = "uksouth" # local.regions[random_integer.region_index.result]
+}
+```
+
+<!-- markdownlint-disable MD033 -->
+## Requirements
+
+The following requirements are needed by this module:
+
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9)
+
+- <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2)
+
+- <a name="requirement_azuredevops"></a> [azuredevops](#requirement\_azuredevops) (~> 1.1)
+
+- <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) (~> 4.5)
+
+- <a name="requirement_random"></a> [random](#requirement\_random) (~> 3.5)
+
+## Resources
+
+The following resources are used by this module:
+
+- [azapi_resource_action.resource_provider_registration](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource_action) (resource)
+- [azuredevops_build_definition.this](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/build_definition) (resource)
+- [azuredevops_git_repository.this](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository) (resource)
+- [azuredevops_git_repository_file.this](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/git_repository_file) (resource)
+- [azuredevops_pipeline_authorization.this](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/pipeline_authorization) (resource)
+- [azuredevops_project.this](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/resources/project) (resource)
+- [azurerm_dev_center.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dev_center) (resource)
+- [azurerm_dev_center_project.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/dev_center_project) (resource)
+- [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) (resource)
+- [random_integer.region_index](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/integer) (resource)
+- [random_string.name](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) (resource)
+- [azuredevops_agent_queue.this](https://registry.terraform.io/providers/microsoft/azuredevops/latest/docs/data-sources/agent_queue) (data source)
+- [azurerm_client_config.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) (data source)
+
+<!-- markdownlint-disable MD013 -->
+## Required Inputs
+
+The following input variables are required:
+
+### <a name="input_azure_devops_organization_name"></a> [azure\_devops\_organization\_name](#input\_azure\_devops\_organization\_name)
+
+Description: Azure DevOps Organisation Name
+
+Type: `string`
+
+### <a name="input_azure_devops_personal_access_token"></a> [azure\_devops\_personal\_access\_token](#input\_azure\_devops\_personal\_access\_token)
+
+Description: The personal access token used for authentication to Azure DevOps.
+
+Type: `string`
+
+## Optional Inputs
+
+The following input variables are optional (have default values):
+
+### <a name="input_enable_telemetry"></a> [enable\_telemetry](#input\_enable\_telemetry)
+
+Description: This variable controls whether or not telemetry is enabled for the module.  
+For more information see <https://aka.ms/avm/telemetryinfo>.  
+If it is set to false, then no telemetry will be collected.
+
+Type: `bool`
+
+Default: `true`
+
+## Outputs
+
+The following outputs are exported:
+
+### <a name="output_managed_devops_pool_id"></a> [managed\_devops\_pool\_id](#output\_managed\_devops\_pool\_id)
+
+Description: n/a
+
+### <a name="output_managed_devops_pool_name"></a> [managed\_devops\_pool\_name](#output\_managed\_devops\_pool\_name)
+
+Description: n/a
+
+## Modules
+
+The following Modules are called:
+
+### <a name="module_managed_devops_pool"></a> [managed\_devops\_pool](#module\_managed\_devops\_pool)
+
+Source: ../..
+
+Version:
+
+### <a name="module_regions"></a> [regions](#module\_regions)
+
+Source: Azure/avm-utl-regions/azurerm
+
+Version: 0.3.0
+
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.
+<!-- END_TF_DOCS -->

--- a/examples/default-azapi-v2/_footer.md
+++ b/examples/default-azapi-v2/_footer.md
@@ -1,0 +1,4 @@
+<!-- markdownlint-disable-next-line MD041 -->
+## Data Collection
+
+The software may collect information about you and your use of the software and send it to Microsoft. Microsoft may use this information to provide services and improve our products and services. You may turn off the telemetry as described in the repository. There are also some features in the software that may enable you and Microsoft to collect data from users of your applications. If you use these features, you must comply with applicable law, including providing appropriate notices to users of your applications together with a copy of Microsoft’s privacy statement. Our privacy statement is located at <https://go.microsoft.com/fwlink/?LinkID=824704>. You can learn more about data collection and use in the help documentation and our privacy statement. Your use of the software operates as your consent to these practices.

--- a/examples/default-azapi-v2/_header.md
+++ b/examples/default-azapi-v2/_header.md
@@ -1,0 +1,3 @@
+# Example of deploying DevOps Managed Pools with Public Networking with v4.0.0 of azurerm provider
+
+This deploys the module in its simplest form with the minimum variable inputs for Azure Managed DevOps Pools. It uses public networking.

--- a/examples/default-azapi-v2/main.tf
+++ b/examples/default-azapi-v2/main.tf
@@ -1,0 +1,203 @@
+variable "azure_devops_organization_name" {
+  type        = string
+  description = "Azure DevOps Organisation Name"
+}
+
+variable "azure_devops_personal_access_token" {
+  type        = string
+  description = "The personal access token used for authentication to Azure DevOps."
+  sensitive   = true
+}
+
+locals {
+  tags = {
+    scenario = "default"
+  }
+}
+
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 2"
+    }
+    azuredevops = {
+      source  = "microsoft/azuredevops"
+      version = "~> 1.1"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.5"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+locals {
+  azure_devops_organization_url = "https://dev.azure.com/${var.azure_devops_organization_name}"
+}
+
+provider "azuredevops" {
+  personal_access_token = var.azure_devops_personal_access_token
+  org_service_url       = local.azure_devops_organization_url
+}
+
+resource "random_string" "name" {
+  length  = 6
+  numeric = true
+  special = false
+  upper   = false
+}
+
+resource "azuredevops_project" "this" {
+  name = random_string.name.result
+}
+
+locals {
+  default_branch  = "refs/heads/main"
+  pipeline_file   = "pipeline.yml"
+  repository_name = "example-repo"
+}
+
+resource "azuredevops_git_repository" "this" {
+  project_id     = azuredevops_project.this.id
+  name           = local.repository_name
+  default_branch = local.default_branch
+  initialization {
+    init_type = "Clean"
+  }
+}
+
+resource "azuredevops_git_repository_file" "this" {
+  repository_id = azuredevops_git_repository.this.id
+  file          = local.pipeline_file
+  content = templatefile("${path.module}/${local.pipeline_file}", {
+    agent_pool_name = module.managed_devops_pool.name
+  })
+  branch              = local.default_branch
+  commit_message      = "[skip ci]"
+  overwrite_on_create = true
+}
+
+resource "azuredevops_build_definition" "this" {
+  project_id = azuredevops_project.this.id
+  name       = "Example Build Definition"
+
+  ci_trigger {
+    use_yaml = true
+  }
+
+  repository {
+    repo_type   = "TfsGit"
+    repo_id     = azuredevops_git_repository.this.id
+    branch_name = azuredevops_git_repository.this.default_branch
+    yml_path    = local.pipeline_file
+  }
+}
+
+data "azuredevops_agent_queue" "this" {
+  project_id = azuredevops_project.this.id
+  name       = module.managed_devops_pool.name
+  depends_on = [module.managed_devops_pool]
+}
+
+resource "azuredevops_pipeline_authorization" "this" {
+  project_id  = azuredevops_project.this.id
+  resource_id = data.azuredevops_agent_queue.this.id
+  type        = "queue"
+  pipeline_id = azuredevops_build_definition.this.id
+}
+
+resource "azurerm_resource_group" "this" {
+  location = local.selected_region
+  name     = "rg-${random_string.name.result}"
+}
+
+locals {
+  resource_providers_to_register = {
+    dev_center = {
+      resource_provider = "Microsoft.DevCenter"
+    }
+    devops_infrastructure = {
+      resource_provider = "Microsoft.DevOpsInfrastructure"
+    }
+  }
+}
+
+data "azurerm_client_config" "this" {}
+
+resource "azapi_resource_action" "resource_provider_registration" {
+  for_each = local.resource_providers_to_register
+
+  resource_id = "/subscriptions/${data.azurerm_client_config.this.subscription_id}"
+  type        = "Microsoft.Resources/subscriptions@2021-04-01"
+  action      = "providers/${each.value.resource_provider}/register"
+  method      = "POST"
+}
+
+resource "azurerm_dev_center" "this" {
+  location            = azurerm_resource_group.this.location
+  name                = "dc-${random_string.name.result}"
+  resource_group_name = azurerm_resource_group.this.name
+
+  depends_on = [azapi_resource_action.resource_provider_registration]
+}
+
+resource "azurerm_dev_center_project" "this" {
+  dev_center_id       = azurerm_dev_center.this.id
+  location            = azurerm_resource_group.this.location
+  name                = "dcp-${random_string.name.result}"
+  resource_group_name = azurerm_resource_group.this.name
+}
+
+# This is the module call
+module "managed_devops_pool" {
+  source                                   = "../.."
+  resource_group_name                      = azurerm_resource_group.this.name
+  location                                 = azurerm_resource_group.this.location
+  name                                     = "mdp-${random_string.name.result}"
+  dev_center_project_resource_id           = azurerm_dev_center_project.this.id
+  version_control_system_organization_name = var.azure_devops_organization_name
+  version_control_system_project_names     = [azuredevops_project.this.name]
+  enable_telemetry                         = var.enable_telemetry
+  tags                                     = local.tags
+  depends_on                               = [azapi_resource_action.resource_provider_registration]
+}
+
+output "managed_devops_pool_id" {
+  value = module.managed_devops_pool.resource_id
+}
+
+output "managed_devops_pool_name" {
+  value = module.managed_devops_pool.name
+}
+
+# Region helpers
+module "regions" {
+  source  = "Azure/avm-utl-regions/azurerm"
+  version = "0.3.0"
+}
+
+resource "random_integer" "region_index" {
+  max = length(local.regions) - 1
+  min = 0
+}
+
+locals {
+  excluded_regions = [
+    "westeurope" # Capacity issues
+  ]
+  included_regions = [
+    "australiaeast", "brazilsouth", "canadacentral", "centralus", "westeurope", "germanywestcentral", "italynorth", "japaneast", "uksouth", "eastus", "eastus2", "southafricanorth", "southcentralus", "southeastasia", "switzerlandnorth", "swedencentral", "westus3", "centralindia", "eastasia", "northeurope", "koreacentral"
+  ]
+  regions         = [for region in module.regions.regions : region.name if !contains(local.excluded_regions, region.name) && contains(local.included_regions, region.name)]
+  selected_region = "uksouth" # local.regions[random_integer.region_index.result]
+}

--- a/examples/default-azapi-v2/pipeline.yml
+++ b/examples/default-azapi-v2/pipeline.yml
@@ -1,0 +1,8 @@
+trigger:
+- main
+
+pool: ${agent_pool_name}
+
+steps:
+- script: echo Hello, world!
+  displayName: 'Run a one-line script'

--- a/examples/default-azapi-v2/variables.tf
+++ b/examples/default-azapi-v2/variables.tf
@@ -1,0 +1,9 @@
+variable "enable_telemetry" {
+  type        = bool
+  default     = true
+  description = <<DESCRIPTION
+This variable controls whether or not telemetry is enabled for the module.
+For more information see <https://aka.ms/avm/telemetryinfo>.
+If it is set to false, then no telemetry will be collected.
+DESCRIPTION
+}

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azapi = {
       source  = "azure/azapi"
-      version = "~> 1.15"
+      version = ">= 1.13, < 3"
     }
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
## Description
Added support for AzApi version 2, with backwards compatibility for versions greater than or equal to 1.13
Added example for AzApi v2 for AVM tests.

Fixes #30
Closes #30 


## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [ x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x ] I'm sure there are no other open Pull Requests for the same update/change
- [ x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
