### PR TITLE
fix: add input for fabricProfile.osProfile.logonType

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,14 @@ Type: `string`
 
 Default: `"azuredevops"`
 
+### <a name="input_fabric_profile_os_profile_logon_type"></a> [fabric\_profile\_os\_profile\_logon\_type](#input\_fabric\_profile\_os\_profile\_logon\_type)
+
+Description: The logon type for the OS profile, possible values are 'Interactive' and 'Service', defaults to 'Service'.
+
+Type: `string`
+
+Default: `"Service"`
+
 ## Outputs
 
 The following outputs are exported:

--- a/README.md
+++ b/README.md
@@ -381,6 +381,14 @@ Type: `string`
 
 Default: `"Premium"`
 
+### <a name="input_fabric_profile_os_profile_logon_type"></a> [fabric\_profile\_os\_profile\_logon\_type](#input\_fabric\_profile\_os\_profile\_logon\_type)
+
+Description: The logon type for the OS profile, possible values are 'Interactive' and 'Service', defaults to 'Service'.
+
+Type: `string`
+
+Default: `"Service"`
+
 ### <a name="input_fabric_profile_sku_name"></a> [fabric\_profile\_sku\_name](#input\_fabric\_profile\_sku\_name)
 
 Description: The SKU name of the fabric profile, make sure you have enough quota for the SKU, the CPUs are multiplied by the `maximum_concurrency` value, make sure you request enough quota, defaults to 'Standard\_D2ads\_v5' which has 2 vCPU Cores. so if maximum\_concurrency is 2, you will need quota for 4 vCPU Cores and so on.
@@ -551,14 +559,6 @@ Description: The type of version control system. This is shortcut alternative to
 Type: `string`
 
 Default: `"azuredevops"`
-
-### <a name="input_fabric_profile_os_profile_logon_type"></a> [fabric\_profile\_os\_profile\_logon\_type](#input\_fabric\_profile\_os\_profile\_logon\_type)
-
-Description: The logon type for the OS profile, possible values are 'Interactive' and 'Service', defaults to 'Service'.
-
-Type: `string`
-
-Default: `"Service"`
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ resource "azapi_resource" "managed_devops_pool" {
           subnetId = var.subnet_id
         } : null
         osProfile = {
-          logonType = "Service"
+          logonType = var.fabric_profile_os_profile_logon_type
         }
         storageProfile = {
           osDiskStorageAccountType = var.fabric_profile_os_disk_storage_account_type

--- a/variables.tf
+++ b/variables.tf
@@ -473,3 +473,14 @@ variable "version_control_system_type" {
     error_message = "The version_control_system_type must be one of: 'azuredevops' or 'github'."
   }
 }
+
+variable "fabric_profile_os_profile_logon_type" {
+  type        = string
+  default     = "Service"
+  description = "The logon type for the OS profile, possible values are 'Interactive' and 'Service', defaults to 'Service'."
+
+  validation {
+    condition     = can(index(["Interactive", "Service"], var.fabric_profile_os_profile_logon_type))
+    error_message = "The fabric_profile_os_profile_logon_type must be one of: 'Interactive' or 'Service'."
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -315,6 +315,17 @@ variable "fabric_profile_os_disk_storage_account_type" {
   }
 }
 
+variable "fabric_profile_os_profile_logon_type" {
+  type        = string
+  default     = "Service"
+  description = "The logon type for the OS profile, possible values are 'Interactive' and 'Service', defaults to 'Service'."
+
+  validation {
+    condition     = can(index(["Interactive", "Service"], var.fabric_profile_os_profile_logon_type))
+    error_message = "The fabric_profile_os_profile_logon_type must be one of: 'Interactive' or 'Service'."
+  }
+}
+
 variable "fabric_profile_sku_name" {
   type        = string
   default     = "Standard_D2ads_v5"
@@ -471,16 +482,5 @@ variable "version_control_system_type" {
   validation {
     condition     = can(index(["azuredevops", "github"], var.version_control_system_type))
     error_message = "The version_control_system_type must be one of: 'azuredevops' or 'github'."
-  }
-}
-
-variable "fabric_profile_os_profile_logon_type" {
-  type        = string
-  default     = "Service"
-  description = "The logon type for the OS profile, possible values are 'Interactive' and 'Service', defaults to 'Service'."
-
-  validation {
-    condition     = can(index(["Interactive", "Service"], var.fabric_profile_os_profile_logon_type))
-    error_message = "The fabric_profile_os_profile_logon_type must be one of: 'Interactive' or 'Service'."
   }
 }


### PR DESCRIPTION
## Description

Closes #37 

- Per doc that data is of type **string**: https://learn.microsoft.com/en-us/azure/templates/microsoft.devopsinfrastructure/pools?pivots=deployment-language-terraform#fabricprofile-objects-2
- That capability matches the checkbox "enable interactive mode" whenever you create it manually

## Type of Change

- New variable: `fabric_profile_os_profile_logon_type`  
  I followed the style of variable you made for the **sku**: `fabric_profile_sku_name`. Which is also a field inside a struct.   
- Update readme for the new input

### Note
- I believe you are actively developing the Managed DevOps Pool, so you should consider allowing to give the whole object `osProfile` to avoid breaking changes in a future update. 
- From what I noticed the only possible values are `Service` or `Interactive`

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->

# Assets
**Fabric profile data example from Azure:**
```
{
    "sku": {
        "name": "Standard_DS11_v2"
    },
    "images": [
        {
            "aliases": [
                "windows-2022",
                "windows-2022/latest"
            ],
            "buffer": "*",
            "wellKnownImageName": "windows-2022"
        },
        {
            "aliases": [
                "windows-2019",
                "windows-2019/latest"
            ],
            "buffer": "*",
            "wellKnownImageName": "windows-2019"
        }
    ],
    "osProfile": {
        "logonType": "Interactive"
    },
    "storageProfile": {
        "osDiskStorageAccountType": "Premium",
        "dataDisks": []
    },
    "networkProfile": null,
    "kind": "Vmss"
}
```