### PR TITLE
chore: Update Terraform required_version for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ module "managed_devops_pool" {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (>= 1.13, < 3)
 

--- a/examples/default-azapi-v2/README.md
+++ b/examples/default-azapi-v2/README.md
@@ -22,7 +22,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"
@@ -214,7 +214,7 @@ locals {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 2)
 

--- a/examples/default-azapi-v2/main.tf
+++ b/examples/default-azapi-v2/main.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"

--- a/examples/default-v4/README.md
+++ b/examples/default-v4/README.md
@@ -22,7 +22,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"
@@ -214,7 +214,7 @@ locals {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 1.14)
 

--- a/examples/default-v4/main.tf
+++ b/examples/default-v4/main.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"

--- a/examples/default/README.md
+++ b/examples/default/README.md
@@ -24,7 +24,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"
@@ -216,7 +216,7 @@ locals {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 1.14)
 

--- a/examples/default/main.tf
+++ b/examples/default/main.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"

--- a/examples/multiple-agent-images/README.md
+++ b/examples/multiple-agent-images/README.md
@@ -26,7 +26,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"
@@ -267,7 +267,7 @@ locals {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 1.14)
 

--- a/examples/multiple-agent-images/main.tf
+++ b/examples/multiple-agent-images/main.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"

--- a/examples/private-networking/README.md
+++ b/examples/private-networking/README.md
@@ -29,7 +29,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"
@@ -328,7 +328,7 @@ locals {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 1.14)
 

--- a/examples/private-networking/main.tf
+++ b/examples/private-networking/main.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"

--- a/examples/standby-agent-automatic/README.md
+++ b/examples/standby-agent-automatic/README.md
@@ -26,7 +26,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"
@@ -232,7 +232,7 @@ locals {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 1.14)
 

--- a/examples/standby-agent-automatic/main.tf
+++ b/examples/standby-agent-automatic/main.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"

--- a/examples/standby-agent-manual/README.md
+++ b/examples/standby-agent-manual/README.md
@@ -28,7 +28,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"
@@ -290,7 +290,7 @@ locals {
 
 The following requirements are needed by this module:
 
-- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9)
+- <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) (>= 1.9, < 2.0)
 
 - <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) (~> 1.14)
 

--- a/examples/standby-agent-manual/main.tf
+++ b/examples/standby-agent-manual/main.tf
@@ -16,7 +16,7 @@ locals {
 }
 
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"

--- a/terraform.tf
+++ b/terraform.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.9"
+  required_version = ">= 1.9, < 2.0"
   required_providers {
     azapi = {
       source  = "azure/azapi"


### PR DESCRIPTION
## Description

This PR updates the Terraform `required_version` constraint to ensure consistency across all AVM modules. The constraint has been set to `>= 1.9, < 2.0` to maintain compatibility and leverage the features available in Terraform versions within this range.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g., CI/CD, documentation, etc.)
- [ ] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [x] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!-- Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
