### PR TITLE
Support runtimeConfiguration.workFolder via API version 2025-09-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,16 @@ Type: `string`
 
 Default: `"azuredevops"`
 
+### <a name="input_work_folder"></a> [work\_folder](#input\_work\_folder)
+
+Description: Optional custom agent work folder, applied to every agent in the pool via `runtimeConfiguration.workFolder`. For example, set this to a path on an attached data disk (e.g. `/mnt/storage/sdc/w` on Linux) to route the agent's working directory off the OS disk.
+
+Requires API version `2025-09-20` or later, which this module now targets. See <https://learn.microsoft.com/en-us/azure/devops/managed-devops-pools/configure-storage> for details. If left `null`, no `runtimeConfiguration` is sent and the platform default work folder applies.
+
+Type: `string`
+
+Default: `null`
+
 ## Outputs
 
 The following outputs are exported:

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ resource "azapi_resource" "managed_devops_pool" {
   location  = var.location
   name      = var.name
   parent_id = "/subscriptions/${local.subscription_id}/resourceGroups/${var.resource_group_name}"
-  type      = "Microsoft.DevOpsInfrastructure/pools@2024-10-19"
+  type      = "Microsoft.DevOpsInfrastructure/pools@2025-09-20"
   body = {
     properties = {
       devCenterProjectResourceId = var.dev_center_project_resource_id
@@ -43,6 +43,10 @@ resource "azapi_resource" "managed_devops_pool" {
         }
         kind = "Vmss"
       }
+
+      runtimeConfiguration = var.work_folder != null ? {
+        workFolder = var.work_folder
+      } : null
     }
   }
   create_headers = var.enable_telemetry ? { "User-Agent" : local.avm_azapi_header } : null

--- a/variables.tf
+++ b/variables.tf
@@ -510,3 +510,13 @@ variable "version_control_system_type" {
     error_message = "The version_control_system_type must be one of: 'azuredevops' or 'github'."
   }
 }
+
+variable "work_folder" {
+  type        = string
+  default     = null
+  description = <<DESCRIPTION
+Optional custom agent work folder, applied to every agent in the pool via `runtimeConfiguration.workFolder`. For example, set this to a path on an attached data disk (e.g. `/mnt/storage/sdc/w` on Linux) to route the agent's working directory off the OS disk.
+
+Requires API version `2025-09-20` or later, which this module now targets. See <https://learn.microsoft.com/en-us/azure/devops/managed-devops-pools/configure-storage> for details. If left `null`, no `runtimeConfiguration` is sent and the platform default work folder applies.
+DESCRIPTION
+}


### PR DESCRIPTION
## Description

Bumps the `Microsoft.DevOpsInfrastructure/pools` API version from `2024-10-19` to `2025-09-20` and adds an optional `work_folder` variable mapped to the new `runtimeConfiguration.workFolder` property.

Relates to #91.

### Motivation

`runtimeConfiguration.workFolder` lets a pool route the agent's working directory onto an attached data disk (`fabric_profile_data_disks`) instead of the OS disk. The property only exists from API version `2025-09-20` onward (see [Configure agent storage](https://learn.microsoft.com/en-us/azure/devops/managed-devops-pools/configure-storage)), which this module predates, so today it can only be set through the Azure portal with no Terraform-owned mechanism - risking drift if the pool is ever recreated.

### Changes

- `main.tf`: bump the `azapi_resource` type to `...@2025-09-20`; add `runtimeConfiguration = var.work_folder != null ? { workFolder = var.work_folder } : null`.
- `variables.tf`: add `work_folder` (optional `string`, default `null`).
- `README.md`: regenerated via `terraform-docs -c .terraform-docs.yml .`.

No other behavior changes - `work_folder` defaults to `null`, so `runtimeConfiguration` is omitted entirely unless explicitly set.

### Validation

- `terraform fmt -recursive -diff` - no changes
- `terraform validate` - success
- `tflint` - no findings
- Not run: this repo's managed e2e CI (`pr-check.yml` skips it for forked-repo PRs, per the standard AVM external-contribution flow) - happy to have a maintainer push this branch to a non-fork branch or otherwise trigger it if required before merge.


---

Fixes #91

<!-- gh-aw-workflow-id: issue-triage -->