### PR TITLE
fix: permanent drift on Off and Automatic resource prediction profiles

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,18 +1,29 @@
 locals {
-  agent_profile = merge(local.agent_profile_base, local.agent_profile_stateful)
+  agent_profile = merge(local.agent_profile_base, local.agent_profile_stateful, local.agent_profile_resource_predictions)
   # Workaround to avoid Payload API Spec Validation error, having gracePeriodTimeSpan and maxAgentLifetime in the agentProfile object, even though they had Null value.
   agent_profile_base = {
     kind                       = var.agent_profile_kind
     resourcePredictionsProfile = local.resource_prediction_profile
-    resourcePredictions = var.agent_profile_resource_prediction_profile == "Manual" ? {
-      timeZone = var.agent_profile_resource_predictions_manual.time_zone
-      daysData = var.agent_profile_resource_predictions_manual.days_data
-    } : null
   }
   agent_profile_resource_prediction_profile_automatic = {
     kind                 = var.agent_profile_resource_prediction_profile_automatic.kind
     predictionPreference = var.agent_profile_resource_prediction_profile_automatic.prediction_preference
   }
+  # resourcePredictions is part of the request body for the Manual profile only. For Off and
+  # Automatic the key is omitted entirely rather than sent as null, because in those modes the
+  # service owns the field: under Automatic it computes the standby agent schedule itself and
+  # writes the result back into resourcePredictions. A key present with a null value is still
+  # part of the body and is compared against the response, so sending null makes every plan
+  # report the field as changed outside Terraform and every apply overwrite the service's value
+  # with null again, which also recycles the agent fleet each time. Omitting the key leaves the
+  # field untracked, which is what Automatic needs. lifecycle ignore_changes cannot be used
+  # instead, because it is a meta-argument and cannot be made conditional on an input.
+  agent_profile_resource_predictions = var.agent_profile_resource_prediction_profile == "Manual" ? {
+    resourcePredictions = {
+      timeZone = var.agent_profile_resource_predictions_manual.time_zone
+      daysData = var.agent_profile_resource_predictions_manual.days_data
+    }
+  } : {}
   agent_profile_stateful = var.agent_profile_kind == "Stateful" ? {
     gracePeriodTimeSpan = var.agent_profile_grace_period_time_span
     maxAgentLifetime    = var.agent_profile_max_agent_lifetime


### PR DESCRIPTION
## Description

Fixes permanent drift on azapi_resource.managed_devops_pool when the agent profile
resource prediction profile is Off or Automatic.

Context. local.agent_profile_base always includes the resourcePredictions key, set to
null unless the profile is Manual. For Off and Automatic the service owns that field,
under Automatic it computes the standby agent schedule itself and writes the result
back into resourcePredictions. A key that is present with a null value is still part
of the azapi request body and is compared against the API response, so the provider
tracks it. The effect is a loop that never converges. Every plan reports
resourcePredictions as changed outside Terraform, and every apply writes null over the
value the service calculated. On a Stateful pool that also recycles the agent fleet on
each apply, so the next queued job waits for a cold agent.

The fix omits the key entirely rather than sending it as null. resourcePredictions is
moved out of agent_profile_base into its own conditional local, which returns the key
for Manual and an empty object otherwise, and that is merged into agent_profile
alongside the existing agent_profile_stateful. Omitting the key leaves the field
untracked, which is what Off and Automatic need.

A lifecycle ignore_changes block is not an alternative here. It is a meta-argument, so
it cannot be made conditional on an input, and it would therefore also stop Manual
schedules being managed. The module does not expose the azapi provider's
ignore_null_property either, so a consumer has no way to suppress this from outside.

Backwards compatible. For the Manual profile the request body is unchanged, the same
timeZone and daysData are sent. For Off and Automatic the only change is that a key
which was previously sent as null is no longer sent, which is the bug being fixed. No
variables or outputs change, so the generated documentation is unaffected.

Verified by evaluating the module's locals for all three settings of
agent_profile_resource_prediction_profile. resourcePredictions is absent from the
resulting agentProfile object for Off and Automatic, and present for Manual. Reproduced
against version 0.3.1 and current main, on a Stateful pool using the Automatic profile
with prediction preference Balanced.

Scope of the change is a single file, locals.tf, 16 insertions and 5 deletions.

Closes #129

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [x] Bugfix containing backwards compatible bug fixes
    - [x] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [ ] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [ ] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks


---

Fixes #127

<!-- gh-aw-workflow-id: issue-triage -->