### PR TITLE
feat: add diagnostic settings example

### DIFF
--- a/examples/private-networking/README.md
+++ b/examples/private-networking/README.md
@@ -4,7 +4,7 @@
 
 >**⚠️WARNING!⚠️**: THIS IS A PREVIEW SERVICE, MICROSOFT MAY NOT PROVIDE SUPPORT FOR THIS, PLEASE CHECK THE PRODUCT DOCS FOR CLARIFICATION
 
-This deploys the module with Private Networking for Azure Managed DevOps Pools.
+This deploys the module with Private Networking for Azure Managed DevOps Pools and sends all supported logs to a Log Analytics workspace.
 
 There are some points of note for this example:
 
@@ -253,10 +253,17 @@ module "managed_devops_pool" {
   source = "../.."
 
   dev_center_project_resource_id = azurerm_dev_center_project.this.id
-  location                       = azurerm_resource_group.this.location
-  name                           = "mdp-${random_string.name.result}"
-  resource_group_name            = azurerm_resource_group.this.name
-  enable_telemetry               = var.enable_telemetry
+  diagnostic_settings = {
+    all_logs = {
+      log_groups            = ["allLogs"]
+      metric_categories     = []
+      workspace_resource_id = azurerm_log_analytics_workspace.this.id
+    }
+  }
+  location            = azurerm_resource_group.this.location
+  name                = "mdp-${random_string.name.result}"
+  resource_group_name = azurerm_resource_group.this.name
+  enable_telemetry    = var.enable_telemetry
   organization_profile = {
     organizations = [{
       name     = var.azure_devops_organization_name

--- a/examples/private-networking/_header.md
+++ b/examples/private-networking/_header.md
@@ -2,7 +2,7 @@
 
 >**⚠️WARNING!⚠️**: THIS IS A PREVIEW SERVICE, MICROSOFT MAY NOT PROVIDE SUPPORT FOR THIS, PLEASE CHECK THE PRODUCT DOCS FOR CLARIFICATION
 
-This deploys the module with Private Networking for Azure Managed DevOps Pools.
+This deploys the module with Private Networking for Azure Managed DevOps Pools and sends all supported logs to a Log Analytics workspace.
 
 There are some points of note for this example:
 

--- a/examples/private-networking/main.tf
+++ b/examples/private-networking/main.tf
@@ -239,10 +239,17 @@ module "managed_devops_pool" {
   source = "../.."
 
   dev_center_project_resource_id = azurerm_dev_center_project.this.id
-  location                       = azurerm_resource_group.this.location
-  name                           = "mdp-${random_string.name.result}"
-  resource_group_name            = azurerm_resource_group.this.name
-  enable_telemetry               = var.enable_telemetry
+  diagnostic_settings = {
+    all_logs = {
+      log_groups            = ["allLogs"]
+      metric_categories     = []
+      workspace_resource_id = azurerm_log_analytics_workspace.this.id
+    }
+  }
+  location            = azurerm_resource_group.this.location
+  name                = "mdp-${random_string.name.result}"
+  resource_group_name = azurerm_resource_group.this.name
+  enable_telemetry    = var.enable_telemetry
   organization_profile = {
     organizations = [{
       name     = var.azure_devops_organization_name


### PR DESCRIPTION
## Description

Updates the private-networking example to route all supported Managed DevOps Pool logs to its Log Analytics workspace. Metric categories are explicitly disabled so the example does not exercise the deprecated metric block tracked in #85.

Closes #4

## Type of Change

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [x] Update to documentation

## Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all pre-commit checks

## Validation

- `avm pre-commit` — passed
- `terraform validate` for `examples/private-networking` — passed
- `avm pr-check` — sync, format, transform, and lint passed; the policy step could not complete locally because the example requires `azure_devops_organization_name` and `azure_devops_personal_access_token` inputs.